### PR TITLE
Primex and Circtest Fixes. Docker fix

### DIFF
--- a/.github/workflows/multi_docker_nightly.yml
+++ b/.github/workflows/multi_docker_nightly.yml
@@ -1,7 +1,6 @@
 name: Multi-arch docker nightly
 
 on:
-  push:
   schedule:
     - cron: '0 11 * * *'
 

--- a/.github/workflows/multi_docker_nightly.yml
+++ b/.github/workflows/multi_docker_nightly.yml
@@ -1,6 +1,7 @@
 name: Multi-arch docker nightly
 
 on:
+  push:
   schedule:
     - cron: '0 11 * * *'
 

--- a/.github/workflows/run_circtools_circtest.yml
+++ b/.github/workflows/run_circtools_circtest.yml
@@ -1,7 +1,6 @@
 name: circtools circtest (pip)
 
 on:
-  push:
   workflow_run:
     workflows: ["API Health Check"]
     types: [completed]

--- a/.github/workflows/run_circtools_circtest.yml
+++ b/.github/workflows/run_circtools_circtest.yml
@@ -1,6 +1,7 @@
 name: circtools circtest (pip)
 
 on:
+  push:
   workflow_run:
     workflows: ["API Health Check"]
     types: [completed]
@@ -67,14 +68,21 @@ jobs:
       with:
         r-version: ${{ matrix.R }}
 
-    - name: Install R dependencies (with retry)
+    - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 20
+        timeout_minutes: 40  
         max_attempts: 3
         retry_on: error
         command: |
-          Rscript circtools/scripts/install_R_dependencies.R)
+          # Configure CRAN binaries on Linux runners
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            UBUNTU_VERSION=$(lsb_release -cs)  # e.g. jammy, noble
+            echo "options(repos = c(RSPM = sprintf('https://packagemanager.posit.co/cran/__linux__/%s/latest', '$UBUNTU_VERSION')))" >> ~/.Rprofile
+          fi
+
+          # Run your dependency installer
+          Rscript circtools/scripts/install_R_dependencies.R
       env:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run_circtools_circtest.yml
+++ b/.github/workflows/run_circtools_circtest.yml
@@ -61,7 +61,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
       continue-on-error: true
       
 
@@ -70,7 +70,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
 
     - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3

--- a/.github/workflows/run_circtools_circtest.yml
+++ b/.github/workflows/run_circtools_circtest.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
     - name: Updating setuptools
       run: |
          python3 -m pip install -U pip setuptools
@@ -59,13 +60,16 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
       continue-on-error: true
+      
 
     - name: Retry Set up R if failed
       if: steps.setup-r.outcome == 'failure'
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
 
     - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3

--- a/.github/workflows/run_circtools_circtest.yml
+++ b/.github/workflows/run_circtools_circtest.yml
@@ -1,6 +1,7 @@
 name: circtools circtest (pip)
 
 on:
+  push:
   workflow_run:
     workflows: ["API Health Check"]
     types: [completed]

--- a/.github/workflows/run_circtools_conservation.yml
+++ b/.github/workflows/run_circtools_conservation.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
     - name: Updating setuptools
       run: |
          python3 -m pip install -U pip setuptools

--- a/.github/workflows/run_circtools_detect.yml
+++ b/.github/workflows/run_circtools_detect.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
     - name: Updating setuptools
       run: |
          python3 -m pip install -U pip setuptools

--- a/.github/workflows/run_circtools_nanopore.yml
+++ b/.github/workflows/run_circtools_nanopore.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
 
     - name: Updating setuptools
       run: |

--- a/.github/workflows/run_circtools_padlock.yml
+++ b/.github/workflows/run_circtools_padlock.yml
@@ -60,7 +60,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
       continue-on-error: true
 
     - name: Retry Set up R if failed
@@ -68,7 +68,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
 
     
     - name: Install R dependencies (with retry, prefer binaries)

--- a/.github/workflows/run_circtools_padlock.yml
+++ b/.github/workflows/run_circtools_padlock.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
     - name: Updating setuptools
       run: |
          python3 -m pip install -U pip setuptools
@@ -59,6 +60,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
       continue-on-error: true
 
     - name: Retry Set up R if failed
@@ -66,6 +68,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
 
     
     - name: Install R dependencies (with retry, prefer binaries)

--- a/.github/workflows/run_circtools_primer.yml
+++ b/.github/workflows/run_circtools_primer.yml
@@ -60,7 +60,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
       continue-on-error: true
 
     - name: Retry Set up R if failed
@@ -68,7 +68,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
-        cache: ''
+        use-public-rspm: false
 
     - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3

--- a/.github/workflows/run_circtools_primer.yml
+++ b/.github/workflows/run_circtools_primer.yml
@@ -1,6 +1,7 @@
 name: circtools primex (pip)
 
 on:
+  push:
   workflow_run:
     workflows: ["API Health Check"]
     types: [completed]
@@ -67,14 +68,21 @@ jobs:
       with:
         r-version: ${{ matrix.R }}
 
-    - name: Install R dependencies (with retry)
+    - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 20
+        timeout_minutes: 40  
         max_attempts: 3
         retry_on: error
         command: |
-          Rscript circtools/scripts/install_R_dependencies.R)
+          # Configure CRAN binaries on Linux runners
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            UBUNTU_VERSION=$(lsb_release -cs)  # e.g. jammy, noble
+            echo "options(repos = c(RSPM = sprintf('https://packagemanager.posit.co/cran/__linux__/%s/latest', '$UBUNTU_VERSION')))" >> ~/.Rprofile
+          fi
+
+          # Run your dependency installer
+          Rscript circtools/scripts/install_R_dependencies.R
       env:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run_circtools_primer.yml
+++ b/.github/workflows/run_circtools_primer.yml
@@ -1,7 +1,6 @@
 name: circtools primex (pip)
 
 on:
-  push:
   workflow_run:
     workflows: ["API Health Check"]
     types: [completed]

--- a/.github/workflows/run_circtools_primer.yml
+++ b/.github/workflows/run_circtools_primer.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: ''
     - name: Updating setuptools
       run: |
          python3 -m pip install -U pip setuptools
@@ -59,6 +60,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
       continue-on-error: true
 
     - name: Retry Set up R if failed
@@ -66,6 +68,7 @@ jobs:
       uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.R }}
+        cache: ''
 
     - name: Install R dependencies (with retry, prefer binaries)
       uses: nick-fields/retry@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
     g++  \
     gfortran \
     r-base  \
+    pandoc \
     python3 \
     python3-dev  \
     python3-pip  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL stage=builder
 LABEL maintainer="tjakobi@arizona.edu"

--- a/circtools/scripts/install_R_dependencies.R
+++ b/circtools/scripts/install_R_dependencies.R
@@ -71,14 +71,13 @@ install.packages("https://cran.r-project.org/src/contrib/Archive/ggstats/ggstats
 # --- GitHub packages ---
 message("\nInstalling GitHub R packages (circTest and primex)...")
 
-if (!requireNamespace("devtools", quietly = TRUE)) {
-  install.packages("devtools", repos="https://cloud.r-project.org")
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes", repos="https://cloud.r-project.org")
 }
-library(devtools)
 
+remotes::install_github("dieterich-lab/CircTest")
+remotes::install_github("dieterich-lab/primex")
 
-devtools::install_github("dieterich-lab/CircTest")
-devtools::install_github("dieterich-lab/primex")
 
 # --- Local source installs ---
 message("\nInstalling local R packages (primex, circtest)...")

--- a/circtools/scripts/install_R_dependencies.R
+++ b/circtools/scripts/install_R_dependencies.R
@@ -71,7 +71,11 @@ install.packages("https://cran.r-project.org/src/contrib/Archive/ggstats/ggstats
 # --- GitHub packages ---
 message("\nInstalling GitHub R packages (circTest and primex)...")
 
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  install.packages("devtools", repos="https://cloud.r-project.org")
+}
 library(devtools)
+
 
 devtools::install_github("dieterich-lab/CircTest")
 devtools::install_github("dieterich-lab/primex")


### PR DESCRIPTION
Devtools kept failing on github install step, so I switched it to "remotes" install_github equivalent. 

For primex and circtest, I just forget to bring over an R fix that I had from other workflows.

